### PR TITLE
Added `Grid.Column="2"` to the Button "Delete"

### DIFF
--- a/exercise2/Notes/MainPage.xaml
+++ b/exercise2/Notes/MainPage.xaml
@@ -18,7 +18,7 @@
                         WidthRequest="100"
                         Clicked="OnSaveButtonClicked" />
 
-            <Button 
+            <Button Grid.Column="2"
                     Text="Delete" 
                     WidthRequest="100"
                     Clicked="OnDeleteButtonClicked" />


### PR DESCRIPTION
Button Delete didn't have the attribute `Grid.Column="2"` and because of that the "Save" button was not visible.